### PR TITLE
Store crs information in `DataBackendRaster`

### DIFF
--- a/R/DataBackendRaster.R
+++ b/R/DataBackendRaster.R
@@ -66,6 +66,7 @@ DataBackendRaster = R6Class("DataBackendRaster",
       private$.data = unique(sources) # nolint
       private$.categories = terra::cats(data)
       private$.layer_names = names(data)
+      private$.crs = terra::crs(data)
 
       # cache default active fields
       private$.rownames = 1:terra::ncell(data)
@@ -257,6 +258,7 @@ DataBackendRaster = R6Class("DataBackendRaster",
         }
       })
       terra::set.names(stack, private$.layer_names)
+      terra::crs(stack) = private$.crs
       stack
     }
   ),
@@ -268,6 +270,7 @@ DataBackendRaster = R6Class("DataBackendRaster",
     # stack
     .categories = NULL,
     .layer_names = NULL,
+    .crs = NULL,
 
     # cache
     .rownames = NULL,

--- a/R/data.R
+++ b/R/data.R
@@ -61,6 +61,7 @@ demo_stack_rasterbrick = function(size = 50, layers = 5) {
     rep(FALSE, ceiling(dimension^2 / 2))), nrow = dimension))
   brick = raster::brick(c(raster_features, list(raster_response)))
   names(brick) = c(paste0("x_", 1:(layers - 1)), "y")
+  raster::crs(brick) = "EPSG:4326"
   brick
 }
 

--- a/tests/testthat/test-DataBackendRaster.R
+++ b/tests/testthat/test-DataBackendRaster.R
@@ -21,6 +21,9 @@ test_that("DataBackendRaster works with a single numeric layer", {
   # stack
   expect_names(names(backend$stack), identical.to = "x_1")
 
+  # crs
+  expect_length(terra::crs(backend$stack, describe = TRUE), 5L)
+
   # data
   expect_data_table(backend$data(rows = seq(100), cols = "x_1"), nrows = 100, ncols = 1, col.names = "strict", types = "numeric") # block read
   expect_names(names(backend$data(rows = seq(100), cols = "x_1")), identical.to = "x_1")
@@ -515,6 +518,8 @@ test_that("DataBackendRaster + stars", {
   expect_names(names(data), identical.to = c("band1", "band2"))
   expect_numeric(data$band1)
 
+  expect_length(terra::crs(backend$stack, describe = TRUE), 5L)
+
 })
 
 # brick input ------------------------------------------------------------------
@@ -535,6 +540,8 @@ test_that("DataBackendRaster + raster", {
   expect_names(names(data), identical.to = c("y", "x_2"))
   expect_numeric(data$y)
 
+  expect_length(terra::crs(backend$stack, describe = TRUE), 5L)
+
 })
 
 # raster input -----------------------------------------------------------------
@@ -554,5 +561,8 @@ test_that("DataBackendRaster + raster", {
   data = backend$distinct(rows = 1:5, cols = "y")
   expect_names(names(data), identical.to = "y")
   expect_numeric(data$y)
+
+  # crs
+  expect_length(terra::crs(backend$stack, describe = TRUE), 5L)
 
 })


### PR DESCRIPTION
Beforehand we did not store CRS information in the stack as all dummy stacks besides the stars one had no CRS set.

I came across this while adding support for `DataBackendRaster` in {mlr3spatiotempcv} with `get_crs()`.

The pretty printer in the test should assure that we always have a valid object to call `terra::crs()` on. The string is saved as the plain PROJ definition and only pretty printed in the test for simplified testing.

fixes #55 