### PR TITLE
remove unused argument 'index' in terra::categories

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -89,7 +89,7 @@ generate_stack = function(layers, layer_size = NULL, dimension = NULL, multi_lay
     } else if (layer$type == "factor") {
       data = matrix(rep(seq_along(layer$levels), each = floor(dimension^2 / length(layer$levels)), length.out = dimension^2), nrow = dimension)
       ras = rast(data)
-      ras = terra::categories(ras, layer = 1, data.table(ID = seq_along(layer$levels), category = layer$levels), index = 2)
+      ras = terra::categories(ras, layer = 1, data.table(ID = seq_along(layer$levels), category = layer$levels))
       if (!layer$in_memory && !multi_layer_file) {
         filename = tempfile(fileext = ".tif")
         writeRaster(ras, filename)

--- a/R/predict_spatial.R
+++ b/R/predict_spatial.R
@@ -75,7 +75,7 @@ predict_spatial = function(newdata, learner, chunksize = 200L, format = "terra",
     if (learner$task_type == "classif") {
       levels = learner$learner$state$train_task$levels()[[learner$learner$state$train_task$target_names]]
       value = data.table(ID = seq_along(levels), categories = levels)
-      target_raster = terra::categories(target_raster, value = value, index = 2)
+      target_raster = terra::categories(target_raster, value = value)
     }
     target_raster = set_names(target_raster, learner$learner$state$train_task$target_names)
 


### PR DESCRIPTION
This PR removes two instances of the use of argument "index=2"` in `terra::categories`.  
The argument was removed from terra::categories a while ago. Using it did not create an error thanks to the ellipses, but I would not like to remove these. Doing so leads to a check error for ml3spatial with terra-dev.