### PR TITLE
feat: add probability prediction to predict_spatial()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mlr3spatial (development version)
 
-* feat: `predict_spatial()` supports probability predictions now. Train a classification learner with `predict_type = "prob"` to get one raster layer or one vector column per class (#88, #89).
+* feat: `predict_spatial()` supports probability predictions now. Train a classification learner with `predict_type = "prob"` to get one raster layer or one vector column per class.
 
 # mlr3spatial 0.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mlr3spatial (development version)
 
+* feat: `predict_spatial()` supports probability predictions now. Train a classification learner with `predict_type = "prob"` to get one raster layer or one vector column per class (#88, #89).
+
 # mlr3spatial 0.6.1
 
 * compatibility: mlr3 1.2.0 removed the data format argument

--- a/R/LearnerClassifSpatial.R
+++ b/R/LearnerClassifSpatial.R
@@ -15,6 +15,7 @@ LearnerClassifSpatial = R6::R6Class(
         packages = learner$packages,
         man = "mlr3learners::mlr_learners_classif.spatial"
       )
+      self$predict_type = learner$predict_type
     },
 
     predict = function(task, row_ids = NULL) {
@@ -26,6 +27,11 @@ LearnerClassifSpatial = R6::R6Class(
       pred$data$row_ids = seq_len(nrow(data))
       pred$data$response = response
       pred$data$truth = rep(NaN, nrow(data))
+      if (self$learner$predict_type == "prob") {
+        prob = matrix(NaN, nrow = nrow(data), ncol = ncol(pred$data$prob), dimnames = list(NULL, colnames(pred$data$prob)))
+        prob[ids, ] = pred$data$prob
+        pred$data$prob = prob
+      }
       pred
     }
   )

--- a/R/LearnerClassifSpatial.R
+++ b/R/LearnerClassifSpatial.R
@@ -7,7 +7,7 @@ LearnerClassifSpatial = R6::R6Class(
     initialize = function(learner) {
       self$learner = assert_learner(learner)
       super$initialize(
-        id = "classif.ranger",
+        id = learner$id,
         param_set = learner$param_set,
         predict_types = learner$predict_types,
         feature_types = learner$feature_types,

--- a/R/LearnerRegrSpatial.R
+++ b/R/LearnerRegrSpatial.R
@@ -7,7 +7,7 @@ LearnerRegrSpatial = R6::R6Class(
     initialize = function(learner) {
       self$learner = assert_learner(learner)
       super$initialize(
-        id = "regr.ranger",
+        id = learner$id,
         param_set = learner$param_set,
         predict_types = learner$predict_types,
         feature_types = learner$feature_types,

--- a/R/predict_spatial.R
+++ b/R/predict_spatial.R
@@ -19,6 +19,11 @@
 #' @param filename (`character(1)`)\cr
 #'   Path where the spatial object should be written to.
 #'
+#' @details
+#' The type of the prediction is taken from the `$predict_type` of the `learner`.
+#' For classification learners with `predict_type = "prob"`,
+#' the probability of each class is returned e.g. as a raster layer per class or as a column per class in an sf object.
+#'
 #' @return Spatial object of class given in argument `format`.
 #' @examples
 #' library(terra, exclude = "resample")
@@ -32,6 +37,11 @@
 #' stack = rast(system.file("extdata", "leipzig_raster.tif", package = "mlr3spatial"))
 #'
 #' # predict land cover classes
+#' pred = predict_spatial(stack, learner, chunksize = 1L)
+#'
+#' # predict land cover probabilities
+#' learner = lrn("classif.rpart", predict_type = "prob")
+#' learner$train(task_train)
 #' pred = predict_spatial(stack, learner, chunksize = 1L)
 #' @export
 predict_spatial = function(newdata, learner, chunksize = 200L, format = "terra", filename = NULL) {
@@ -53,11 +63,21 @@ predict_spatial = function(newdata, learner, chunksize = 200L, format = "terra",
       "regr" = LearnerRegrSpatial$new(learner)
     )
 
+    predict_prob = learner$predict_type == "prob"
+    levels = if (learner$task_type == "classif") {
+      learner$learner$state$train_task$levels()[[learner$learner$state$train_task$target_names]]
+    }
+
     # calculate block size
     bs = block_size(stack, chunksize)
 
-    # initialize target raster
-    target_raster = terra::rast(terra::ext(stack), resolution = terra::res(stack), crs = terra::crs(stack))
+    # initialize target raster with one layer per class when predicting probabilities
+    target_raster = terra::rast(
+      terra::ext(stack),
+      resolution = terra::res(stack),
+      crs = terra::crs(stack),
+      nlyrs = if (predict_prob) length(levels) else 1L
+    )
     terra::writeStart(target_raster, filename = filename, overwrite = TRUE, datatype = "FLT8S")
 
     lg$info("Start raster prediction")
@@ -75,7 +95,7 @@ predict_spatial = function(newdata, learner, chunksize = 200L, format = "terra",
         pred = learner$predict(task, row_ids = cells_seq:((cells_seq + cells_to_read - 1)))
         terra::writeValues(
           x = target_raster,
-          v = pred$response,
+          v = if (predict_prob) pred$prob[, levels, drop = FALSE] else pred$response,
           start = terra::rowFromCell(stack, cells_seq), # start row number
           nrows = terra::rowFromCell(stack, cells_to_read)
         ) # how many rows
@@ -86,12 +106,14 @@ predict_spatial = function(newdata, learner, chunksize = 200L, format = "terra",
     terra::writeStop(target_raster)
     lg$info("Finished raster prediction in %i seconds", as.integer(proc.time()[3] - start_time))
 
-    if (learner$task_type == "classif") {
-      levels = learner$learner$state$train_task$levels()[[learner$learner$state$train_task$target_names]]
+    if (learner$task_type == "classif" && !predict_prob) {
       value = data.table(ID = seq_along(levels), categories = levels)
       target_raster = terra::categories(target_raster, value = value)
     }
-    target_raster = set_names(target_raster, learner$learner$state$train_task$target_names)
+    target_raster = set_names(
+      target_raster,
+      if (predict_prob) levels else learner$learner$state$train_task$target_names
+    )
 
     switch(
       format,
@@ -104,11 +126,18 @@ predict_spatial = function(newdata, learner, chunksize = 200L, format = "terra",
     if (!is.null(filename)) {
       assert_path_for_output(filename)
     }
-    pred = learner$predict(task)
-    vector = set_names(
-      sf::st_as_sf(data.frame(pred$response, task$backend$sfc)),
-      c(learner$state$train_task$target_names, "geometry")
-    )
+    pred = learner$predict_newdata(task$data())
+    vector = if (learner$predict_type == "prob") {
+      set_names(
+        sf::st_as_sf(data.frame(pred$prob, task$backend$sfc)),
+        c(colnames(pred$prob), "geometry")
+      )
+    } else {
+      set_names(
+        sf::st_as_sf(data.frame(pred$response, task$backend$sfc)),
+        c(learner$state$train_task$target_names, "geometry")
+      )
+    }
 
     if (!is.null(filename)) {
       sf::st_write(vector, filename, quiet = TRUE)

--- a/man/predict_spatial.Rd
+++ b/man/predict_spatial.Rd
@@ -47,6 +47,11 @@ Spatial object of class given in argument \code{format}.
 \description{
 This function allows to directly predict mlr3 learners on various spatial objects.
 }
+\details{
+The type of the prediction is taken from the \verb{$predict_type} of the \code{learner}.
+For classification learners with \code{predict_type = "prob"},
+the probability of each class is returned e.g. as a raster layer per class or as a column per class in an sf object.
+}
 \examples{
 library(terra, exclude = "resample")
 
@@ -59,5 +64,10 @@ learner$train(task_train)
 stack = rast(system.file("extdata", "leipzig_raster.tif", package = "mlr3spatial"))
 
 # predict land cover classes
+pred = predict_spatial(stack, learner, chunksize = 1L)
+
+# predict land cover probabilities
+learner = lrn("classif.rpart", predict_type = "prob")
+learner$train(task_train)
 pred = predict_spatial(stack, learner, chunksize = 1L)
 }

--- a/tests/testthat/test_LearnerClassifSpatial.R
+++ b/tests/testthat/test_LearnerClassifSpatial.R
@@ -26,6 +26,34 @@ test_that("LearnerClassifSpatial ignores observations with missing values", {
   expect_numeric(pred$response, any.missing = TRUE, all.missing = FALSE)
 })
 
+test_that("LearnerClassifSpatial returns probabilities for observations with missing values", {
+  # train task
+  stack = generate_stack(
+    list(
+      numeric_layer("x_1"),
+      factor_layer("y", levels = c("a", "b"))
+    ),
+    dimension = 100
+  )
+  vector = sample_stack(stack, n = 100)
+  task_train = as_task_classif_st(vector, id = "test_vector", target = "y")
+  learner = lrn("classif.rpart", predict_type = "prob")
+  learner$train(task_train)
+
+  # predict task
+  stack$y = NULL
+  stack = mask_stack(stack)
+  task_predict = as_task_unsupervised(stack, id = "test")
+  learner_spatial = LearnerClassifSpatial$new(learner)
+  pred = learner_spatial$predict(task_predict)
+
+  expect_equal(learner_spatial$predict_type, "prob")
+  expect_equal(colnames(pred$prob), c("a", "b"))
+  expect_equal(nrow(pred$prob), task_predict$nrow)
+  expect_true(all(is.na(pred$prob[seq(100), ])))
+  expect_matrix(pred$prob, any.missing = TRUE, all.missing = FALSE)
+})
+
 test_that("LearnerClassifSpatial predicts newdata without optional column roles", {
   stack = generate_stack(
     list(

--- a/tests/testthat/test_predict_spatial.R
+++ b/tests/testthat/test_predict_spatial.R
@@ -88,6 +88,82 @@ test_that("sequential execution works in chunks", {
   expect_class(pred, "SpatRaster")
 })
 
+# probability prediction -------------------------------------------------------
+
+test_that("probability predictions are written to raster", {
+  # train
+  stack = generate_stack(
+    list(
+      numeric_layer("x_1"),
+      factor_layer("y", levels = c("a", "b"))
+    ),
+    layer_size = 1
+  )
+  vector = sample_stack(stack, n = 100)
+  task_train = as_task_classif_st(vector, id = "test_vector", target = "y")
+  learner = lrn("classif.rpart", predict_type = "prob")
+  learner$train(task_train)
+
+  # predict
+  stack$y = NULL
+  task_predict = as_task_unsupervised(stack, id = "test")
+  pred = predict_spatial(task_predict, learner, chunksize = 1L)
+  expect_class(pred, "SpatRaster")
+  expect_equal(terra::nlyr(pred), 2L)
+  expect_named(pred, c("a", "b"))
+  values = terra::values(pred)
+  expect_true(all(values >= 0 & values <= 1))
+  expect_equal(unname(rowSums(values)), rep(1, nrow(values)))
+})
+
+test_that("multiclass probability predictions are written to raster", {
+  # train
+  stack = generate_stack(
+    list(
+      numeric_layer("x_1"),
+      factor_layer("y", levels = c("a", "b", "c"))
+    ),
+    layer_size = 1
+  )
+  vector = sample_stack(stack, n = 100)
+  task_train = as_task_classif_st(vector, id = "test_vector", target = "y")
+  learner = lrn("classif.rpart", predict_type = "prob")
+  learner$train(task_train)
+
+  # predict
+  stack$y = NULL
+  task_predict = as_task_unsupervised(stack, id = "test")
+  pred = predict_spatial(task_predict, learner, chunksize = 1L)
+  expect_class(pred, "SpatRaster")
+  expect_equal(terra::nlyr(pred), 3L)
+  expect_named(pred, c("a", "b", "c"))
+})
+
+test_that("probability prediction works with missing values", {
+  # train
+  stack = generate_stack(
+    list(
+      numeric_layer("x_1"),
+      factor_layer("y", levels = c("a", "b"))
+    ),
+    dimension = 100
+  )
+  vector = sample_stack(stack, n = 100)
+  task_train = as_task_classif_st(vector, id = "test_vector", target = "y")
+  learner = lrn("classif.rpart", predict_type = "prob")
+  learner$train(task_train)
+
+  # predict
+  stack$y = NULL
+  stack = mask_stack(stack)
+  task_predict = as_task_unsupervised(stack, id = "test")
+  pred = predict_spatial(task_predict, learner, chunksize = 1L)
+  expect_class(pred, "SpatRaster")
+  expect_named(pred, c("a", "b"))
+  expect_true(all(is.na(terra::values(pred[["a"]])[seq(10)])))
+  expect_numeric(terra::values(pred[["a"]]), any.missing = TRUE, all.missing = FALSE)
+})
+
 # parallel raster predict ------------------------------------------------------
 
 test_that("parallel execution works with multicore", {
@@ -285,4 +361,19 @@ test_that("prediction are written to sf vector", {
   expect_equal(nrow(pred), 97)
   expect_named(pred, c("land_cover", "geometry"))
   expect_class(pred$geometry, "sfc")
+})
+
+test_that("probability predictions are written to sf vector", {
+  task = tsk("leipzig")
+  learner = lrn("classif.rpart", predict_type = "prob")
+  learner$train(task)
+
+  vector = sf::st_read(system.file("extdata", "leipzig_points.gpkg", package = "mlr3spatial"), stringsAsFactors = TRUE, quiet = TRUE)
+  vector$land_cover = NULL
+  task_predict = as_task_unsupervised(vector)
+  pred = predict_spatial(task_predict, learner)
+  expect_class(pred, "sf")
+  expect_equal(nrow(pred), 97)
+  expect_named(pred, c(task$class_names, "geometry"))
+  expect_true(all(sf::st_drop_geometry(pred) >= 0 & sf::st_drop_geometry(pred) <= 1))
 })


### PR DESCRIPTION
Closes #88
Closes #89

## Summary

Reimplementation of #89 on current main. `predict_spatial()` now supports probability predictions. Instead of adding a `predict_type` argument, the prediction type is taken from the `$predict_type` of the learner, so a mismatch between argument and learner state is impossible.

- `LearnerClassifSpatial` mirrors the wrapped learner's `$predict_type` and fills a full-size probability matrix with `NaN` rows for incomplete observations. Only the column names are carried over, which fixes the dimension error with masked rasters reported in #88.
- For rasters, the target raster is initialized with one layer per class and `terra::writeValues()` receives the full probability matrix, so multiclass tasks are supported. Layers are named after the class levels, and the categorical-labels step is skipped for probability output.
- For sf vectors, one probability column per class is returned. The vector branch now uses `$predict_newdata()` instead of `$predict()` because predicting probabilities directly on an unsupervised task fails mlr3's prediction-data check.
- The internal spatial learner wrappers now use the id of the wrapped learner instead of the hardcoded `classif.ranger` / `regr.ranger`.

## Verification

```r
library(mlr3spatial)
library(terra, exclude = "resample")

task_train = tsk("leipzig")
learner = lrn("classif.rpart", predict_type = "prob")
learner$train(task_train)

stack = rast(system.file("extdata", "leipzig_raster.tif", package = "mlr3spatial"))
pred = predict_spatial(stack, learner, chunksize = 1L)
pred # SpatRaster with layers forest, pasture, urban, water
plot(pred)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)