### PR TITLE
fix: partial layer name matching in DataBackendRaster

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mlr3spatial (development version)
 
+* fix: `DataBackendRaster` no longer errors when raster layers have partially matching names, e.g. `predict_spatial()` failed with layers named `"test_name"` and `"test_name2"` (#94).
 * feat: `predict_spatial()` supports probability predictions now. Train a classification learner with `predict_type = "prob"` to get one raster layer or one vector column per class.
 
 # mlr3spatial 0.6.1

--- a/R/DataBackendRaster.R
+++ b/R/DataBackendRaster.R
@@ -41,12 +41,13 @@ DataBackendRaster = R6Class(
       assert_class(data, "SpatRaster")
 
       # write raster to disk
-      sources = map_chr(names(data), function(layer) {
-        if (terra::inMemory(data[layer])) {
+      sources = map_chr(seq_len(terra::nlyr(data)), function(i) {
+        layer = data[[i]]
+        if (terra::inMemory(layer)) {
           filename = tempfile(fileext = ".tif")
-          terra::writeRaster(data[layer], filename = filename)
+          terra::writeRaster(layer, filename = filename)
         } else {
-          filename = terra::sources(data[layer])
+          filename = terra::sources(layer)
         }
         filename
       })
@@ -136,10 +137,10 @@ DataBackendRaster = R6Class(
         stack = terra::subset(self$stack, cols)
         set_names(
           map(cols, function(layer) {
-            if (terra::is.factor(stack[layer])) {
-              terra::cats(stack[layer])[[1]][, 2]
+            if (terra::is.factor(stack[[layer]])) {
+              terra::cats(stack[[layer]])[[1]][, 2]
             } else {
-              terra::unique(stack["x_1"])[[1]]
+              terra::unique(stack[[layer]])[[1]]
             }
           }),
           cols

--- a/tests/testthat/test_DataBackendRaster.R
+++ b/tests/testthat/test_DataBackendRaster.R
@@ -560,6 +560,30 @@ test_that("in memory and disk rasters work", {
   expect_equal(backend$missings(rows = seq(10), cols = c("x_1", "c_1", "c_2")), c("x_1" = 0, "c_1" = 0))
 })
 
+test_that("layers with partially matching names work", {
+  stack = generate_stack(
+    list(
+      numeric_layer("x_1", in_memory = TRUE),
+      numeric_layer("x_12", in_memory = TRUE)
+    ),
+    dimension = 10,
+  )
+
+  backend = DataBackendRaster$new(stack)
+
+  expect_class(backend, "DataBackendRaster")
+  expect_names(backend$colnames, identical.to = c("x_1", "x_12"))
+
+  data = backend$data(rows = seq(100), cols = c("x_1", "x_12"))
+  values = terra::values(stack)
+  expect_equal(data$x_1, unname(values[, "x_1"]), tolerance = 1e-7)
+  expect_equal(data$x_12, unname(values[, "x_12"]), tolerance = 1e-7)
+
+  distinct = backend$distinct(rows = seq(100), cols = c("x_1", "x_12")) # fast query
+  expect_equal(sort(distinct$x_1), sort(unique(data$x_1)))
+  expect_equal(sort(distinct$x_12), sort(unique(data$x_12)))
+})
+
 # as_data_backend input formats ------------------------------------------------
 
 test_that("as_data_backend works on SpatRaster objects", {


### PR DESCRIPTION
Closes #94

## Summary

`DataBackendRaster$initialize()` subset layers with terra's single-bracket operator (`data[layer]`), which performs partial name matching. With layers named e.g. `"test_name"` and `"test_name2"`, `terra::inMemory()` returned a vector of length > 1 and construction failed with `the condition has length > 1`. The constructor now iterates layers by index (`data[[i]]`), which avoids partial matching and also works for layers sharing the exact same name.

The fast path of `$distinct()` had the same single-bracket pattern plus a latent bug: it hardcoded `terra::unique(stack["x_1"])`, so distinct values of any non-factor column were actually those of `x_1`. It now uses `stack[[layer]]` throughout.

## Verification

The reprex from #94 now runs cleanly:

```r
library(mlr3spatial)
library(terra, exclude = "resample")

task_train = tsk("leipzig")
learner = lrn("classif.rpart")
learner$train(task_train)

stack = rast(system.file("extdata", "leipzig_raster.tif", package = "mlr3spatial"))
r = rast(nrows = nrow(stack), ncols = ncol(stack), nlyrs = 2, crs = crs(stack),
  extent = ext(stack), resolution = res(stack), names = c("test_name", "test_name2"))
values(r[[1]]) = runif(ncell(stack))
values(r[[2]]) = runif(ncell(stack))
stack = c(stack, r)

pred = predict_spatial(stack, learner, chunksize = 1L)
```

A regression test covers backend construction, `$data()`, and `$distinct()` with partially matching layer names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)